### PR TITLE
Deduplicate dataset

### DIFF
--- a/src/pg2_benchmark/dummy_data.py
+++ b/src/pg2_benchmark/dummy_data.py
@@ -110,12 +110,10 @@ def charge_mutations(sequence: str, n: int) -> str:
 
 def charge_ladder_dataset(n_rows: int = 200, seq_len: int = 20) -> pd.DataFrame:
     parent = _generate_sequence(seq_len)
-    sequences = [
-        charge_mutations(parent, random.randint(0, seq_len)) for _ in range(n_rows)
-    ]
-
     # Deduplicate sequences
-    sequences = list(set(sequences))
+    sequences = {
+        charge_mutations(parent, random.randint(0, seq_len)) for _ in range(n_rows)
+    }
 
     charge = [peptide_charge(seq) for seq in sequences]
     return pd.DataFrame({"sequence": sequences, "charge": charge})


### PR DESCRIPTION
If the dataset has duplicate sequences, the validation error will occur, due to [this check](https://github.com/ProteinGym2/pg2-dataset/blob/1ac113fa53524b3e6910e16bc440755ed2a1ff61/src/pg2_dataset/backends/assays.py#L222).