### PR TITLE
Build docker images with configurable paths for AWS

### DIFF
--- a/models/esm/src/pg2_model_esm/__main__.py
+++ b/models/esm/src/pg2_model_esm/__main__.py
@@ -47,8 +47,8 @@ def _configure_container_paths(
         with open(dataset_toml_file, "r") as f:
             data = toml.load(f)
 
-        data["assays_meta"]["file_path"] = str(
-            training_data_path / data["assays_meta"]["file_path"]
+        data["assays_meta"]["file_path"] = (
+            f"{training_data_path}{data['assays_meta']['file_path']}"
         )
 
         with open(dataset_toml_file, "w") as f:

--- a/models/pls/src/pg2_model_pls/__main__.py
+++ b/models/pls/src/pg2_model_pls/__main__.py
@@ -44,8 +44,8 @@ def _configure_container_paths(
         with open(dataset_toml_file, "r") as f:
             data = toml.load(f)
 
-        data["assays_meta"]["file_path"] = str(
-            training_data_path / data["assays_meta"]["file_path"]
+        data["assays_meta"]["file_path"] = (
+            f"{training_data_path}{data['assays_meta']['file_path']}"
         )
 
         with open(dataset_toml_file, "w") as f:


### PR DESCRIPTION
## Overview

Build docker images with configurable AWS paths.

## Why

In local, you can mount TOML file paths, but in AWS, you can only mount training data paths, e.g., CSV, so TOML files can only read from hyperparameters.

Besides, in dataset TOML file, its file path also needs to be updated to the mounted S3 path.

## Result

With this update, the Docker file can be used both in local and AWS.

