### PR TITLE
Use hyper_parameters

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -9,7 +9,7 @@ The manifest schema is defined in this section. Let's start with an example foll
 ``` TOML
 name = "esm"
 
-[hyper_params]
+[hyper_parameters]
 location = "esm2_t30_150M_UR50D"
 scoring_strategy = "wt-marginals"
 nogpu = false
@@ -20,7 +20,7 @@ offset_idx = 24
 
 The top-level of the manifest contains the model metadata and its hyper parameters.
 
-| **Field**      | **Type**                              | **Required** | **Default** | **Description**                     |
-|----------------|---------------------------------------|--------------|-------------|-------------------------------------|
-| `name`         | `string`                              | Yes          | N/A         | The name of the model.              |
-| `hyper_params` | `map[str, bool | int | float | str ]` | No           | Empty dict  | The hyper parameters of the model.  |
+| **Field**          | **Type**                              | **Required** | **Default** | **Description**                     |
+|--------------------|---------------------------------------|--------------|-------------|-------------------------------------|
+| `name`             | `string`                              | Yes          | N/A         | The name of the model.              |
+| `hyper_parameters` | `map[str, bool | int | float | str ]` | No           | Empty dict  | The hyper parameters of the model.  |

--- a/models/esm/src/proteingym/models/esm/model.py
+++ b/models/esm/src/proteingym/models/esm/model.py
@@ -28,11 +28,11 @@ def load(model_card: ModelCard) -> tuple[torch.nn.Module, Alphabet]:
         tuple: The loaded ESM model and its corresponding alphabet
     """
     model, alphabet = pretrained.load_model_and_alphabet(
-        model_card.hyper_params["location"]
+        model_card.hyper_parameters["location"]
     )
     model.eval()
 
-    if torch.cuda.is_available() and not model_card.hyper_params["nogpu"]:
+    if torch.cuda.is_available() and not model_card.hyper_parameters["nogpu"]:
         model = model.cuda()
         print("Transferred model to GPU")
 
@@ -83,7 +83,7 @@ def infer(
 
     batch_tokens = encode(reference_sequence, alphabet)
 
-    match model_card.hyper_params["scoring_strategy"]:
+    match model_card.hyper_parameters["scoring_strategy"]:
         case "wt-marginals":
             with torch.no_grad():
                 token_probs = torch.log_softmax(model(batch_tokens)["logits"], dim=-1)
@@ -94,7 +94,7 @@ def infer(
                     reference_sequence,
                     token_probs,
                     alphabet,
-                    model_card.hyper_params["offset_idx"],
+                    model_card.hyper_parameters["offset_idx"],
                 ),
                 axis=1,
             )
@@ -121,7 +121,7 @@ def infer(
                     reference_sequence,
                     token_probs,
                     alphabet,
-                    model_card.hyper_params["offset_idx"],
+                    model_card.hyper_parameters["offset_idx"],
                 ),
                 axis=1,
             )
@@ -135,14 +135,14 @@ def infer(
                     reference_sequence,
                     model,
                     alphabet,
-                    model_card.hyper_params["offset_idx"],
+                    model_card.hyper_parameters["offset_idx"],
                 ),
                 axis=1,
             )
 
         case _:
             raise ValueError(
-                f"Unrecognized scoring strategy: {model_card.hyper_params['scoring_strategy']}"
+                f"Unrecognized scoring strategy: {model_card.hyper_parameters['scoring_strategy']}"
             )
 
     df.rename(columns={"target": "test"}, inplace=True)

--- a/models/pls/src/proteingym/models/pls/model.py
+++ b/models/pls/src/proteingym/models/pls/model.py
@@ -35,9 +35,9 @@ def train(
 
     logger.info(f"Loaded {len(train_Y)} training records and start the training...")
 
-    encodings = encode(spit_X=train_X, hyper_params=model_card.hyper_params)
+    encodings = encode(spit_X=train_X, hyper_params=model_card.hyper_parameters)
 
-    model = PLSRegression(model_card.hyper_params["n_components"])
+    model = PLSRegression(model_card.hyper_parameters["n_components"])
     model.fit(encodings, train_Y)
 
     logger.info("Finished the training.")
@@ -73,7 +73,7 @@ def infer(
 
     logger.info(f"Loaded {len(test_Y)} test records and start the scoring...")
 
-    encodings = encode(spit_X=test_X, hyper_params=model_card.hyper_params)
+    encodings = encode(spit_X=test_X, hyper_params=model_card.hyper_parameters)
 
     preds = model.predict(encodings)
 


### PR DESCRIPTION
# Changes

Currently, the CML pipeline fails because I rename from `hyper_params` to `hyper_parameters` for the model card in proteingym-base.

# Checklist

- [x] I broke the PR down so that it contains a reasonable amount of changes for an effective review
- [x] I performed a self-review of my code. Amongst other things, I have commented my code in hard-to-understand areas.
- [ ] I made corresponding changes to the documentation
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I accounted for dependent changes to be merged and published in downstream modules
