### PR TITLE
Add regex pattern to skip >[warnings or notes pattern

### DIFF
--- a/src/lib/stores/models.ts
+++ b/src/lib/stores/models.ts
@@ -26,10 +26,11 @@ function createModelsStore() {
           const frontmatter = parsedMarkdown.attributes;
           const content = parsedMarkdown.body;
 
-          // Extracts first paragraph of content, skipping any leading headings or whitespace
+          // Extracts first paragraph of content, skipping any leading headings, whitespace, or GitHub alerts
           // Example: "# Title\nThis is the overview\nMore text" -> captures "This is the overview"
           // Example: "  \nFirst paragraph here\nSecond line" -> captures "First paragraph here"
-          const overviewRegex = /^(?:#+[^\n]*\n+|\s)*(.*?)(?=\n|$)/s;
+          // Example: "> [!WARNING]\n> Alert text\nFirst paragraph" -> captures "First paragraph"
+          const overviewRegex = /^(?:#+[^\n]*\n+|>\s*\[!.*?\][\s\S]*?(?=\n(?!>)|\n#|$)|\s)*(.*?)(?=\n|$)/s;
           const overviewMatch = content.match(overviewRegex);
           const overview = overviewMatch?.[1] || "";
 


### PR DESCRIPTION
# Changes

Fix the regex pattern to extract overview from README.md for model cards

# Checklist

- [ ] I broke the PR down so that it contains a reasonable amount of changes for an effective review
- [ ] I performed a self-review of my code. Amongst other things, I have commented my code in hard-to-understand areas.
- [ ] I made corresponding changes to the documentation
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I accounted for dependent changes to be merged and published in downstream modules
