### PR TITLE
switch from personal access token to github token

### DIFF
--- a/.github/workflows/cml.yaml
+++ b/.github/workflows/cml.yaml
@@ -9,6 +9,9 @@ on:
 jobs:
   cml:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -98,7 +101,7 @@ jobs:
       
       - name: Create PR report
         env:
-          repo_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cat <<EOF > report.md
           ✅ The benchmark has been finished successfully.


### PR DESCRIPTION
# Changes

Changed personal access token to github token for the `Create PR report` & `Commit and push DVC lock files`. 

- No longer posts the PR results as one of us, but as github-actions[bot]
- Should resolve issues with bots (e.g. Dependabot) performing PRs & secure access.

# Checklist

- [x] I broke the PR down so that it contains a reasonable amount of changes for an effective review
- [x] I performed a self-review of my code. Amongst other things, I have commented my code in hard-to-understand areas.
- [ ] I made corresponding changes to the documentation
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I accounted for dependent changes to be merged and published in downstream modules
