### PR TITLE
updated cml to install dependencies

### DIFF
--- a/.github/workflows/cml.yaml
+++ b/.github/workflows/cml.yaml
@@ -17,6 +17,11 @@ jobs:
         with:
           fetch-depth: 0
           lfs: true
+          
+      - name: Install system dependencies for CML
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libpixman-1-dev libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 
       - uses: iterative/setup-cml@v2
 

--- a/.github/workflows/cml.yaml
+++ b/.github/workflows/cml.yaml
@@ -11,17 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           lfs: true
-          
-      - name: Install system dependencies for CML
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libpixman-1-dev libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 
       - uses: iterative/setup-cml@v2
 

--- a/.github/workflows/cml.yaml
+++ b/.github/workflows/cml.yaml
@@ -19,6 +19,11 @@ jobs:
         with:
           fetch-depth: 0
           lfs: true
+          
+      - name: Install system dependencies for CML
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libpixman-1-dev libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 
       - uses: iterative/setup-cml@v2
 


### PR DESCRIPTION
# Changes

Resolves #196

CML pipeline misses dependencies

Also switched to Node24 as Node20 is being deprecated. 

# Checklist

- [x] I broke the PR down so that it contains a reasonable amount of changes for an effective review
- [x] I performed a self-review of my code. Amongst other things, I have commented my code in hard-to-understand areas.
- [x] I made corresponding changes to the documentation
- [ ] I added tests that prove my fix is effective or that my feature works
- [x] I accounted for dependent changes to be merged and published in downstream modules
